### PR TITLE
[OPT]add wait timeout for parallel gateway

### DIFF
--- a/core/src/main/java/com/alibaba/smart/framework/engine/constant/ParallelGatewayConstant.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/constant/ParallelGatewayConstant.java
@@ -1,0 +1,21 @@
+package com.alibaba.smart.framework.engine.constant;
+
+/**
+ * 并行网关扩展属性常量
+ *
+ * @author guoxing
+ * @date 2020年11月16日19:29:08
+ */
+public final class ParallelGatewayConstant {
+
+   /**
+    * private scope constructor for avoid new instance
+    */
+   private ParallelGatewayConstant() {
+   }
+
+   /**
+    * 自定义属性名：等待超时时间，单位毫秒。
+    */
+   public static final String WAIT_TIME_OUT = "timeout";
+}


### PR DESCRIPTION
目前并行网关的超时时间是一个流程编排上下文共用一个超时时间的设置。可能出现一个流程图中多个并行操作，每个并行网关超时时间不一样的需求，支持在ParallelGateway的Properties上直接设置超时时间。这样代码调用流程的时候，无需注入超时时间到request上下文。