### PR TITLE
xml解析兼容多种ns

### DIFF
--- a/core/src/main/java/com/alibaba/smart/framework/engine/bpmn/constant/BpmnNameSpaceConstant.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/bpmn/constant/BpmnNameSpaceConstant.java
@@ -6,5 +6,18 @@ public interface BpmnNameSpaceConstant {
 
     String BPMNDI_NAME_SPACE = "http://www.omg.org/spec/BPMN/20100524/DI";
 
+    /**
+     * camunda 命名空间
+     */
+    String CAMUNDA_NAME_SPACE = "http://camunda.org/schema/1.0/bpmn";
+    /**
+     * flowable
+     */
+    String FLOWABLE_NAME_SPACE = "http://flowable.org/bpmn";
+    /**
+     * activiti
+     */
+    String ACTIVITI_NAME_SPACE = "http://activiti.org/bpmn";
+
 
 }

--- a/core/src/main/java/com/alibaba/smart/framework/engine/configuration/impl/DefaultXmlParserFacade.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/configuration/impl/DefaultXmlParserFacade.java
@@ -1,6 +1,7 @@
 package com.alibaba.smart.framework.engine.configuration.impl;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -47,9 +48,35 @@ public class DefaultXmlParserFacade implements
             try {
                 Class aClass = entry.getKey();
                 Object o = aClass.newInstance();
-                Field field = aClass.getField("qtype");
-                QName qName=   (QName)field.get(o);
-                bindingsWithQName.put(qName, entry.getValue());
+
+                Field field = null;
+                QName qName = null;
+                try {
+                    field = aClass.getField("qtype");
+                    qName = (QName) field.get(o);
+                    bindingsWithQName.put(qName, entry.getValue());
+                } catch (Throwable e) {
+                    // ignore NoSuchFieldException
+                }
+
+                // for list
+                try {
+                    field = aClass.getField("qtypes");
+                    List<QName> qNames=  (List<QName>)field.get(o);
+                    if(qNames != null && qNames.size() > 0) {
+                        for(QName item : qNames) {
+                            // single already registered, skip
+                            if(item.equals(qName)) {
+                                continue;
+                            }
+                            bindingsWithQName.put(item, entry.getValue());
+                        }
+                    }
+                } catch (Throwable e) {
+                    // ignore NoSuchFieldException
+                }
+
+
             } catch (Exception e) {
                 //TUNE 堆栈有些乱
                 throw new RuntimeException(e);

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/ExecutionListener.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/ExecutionListener.java
@@ -1,10 +1,12 @@
 package com.alibaba.smart.framework.engine.smart;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import com.alibaba.smart.framework.engine.bpmn.constant.BpmnNameSpaceConstant;
 import com.alibaba.smart.framework.engine.common.util.CollectionUtil;
 import com.alibaba.smart.framework.engine.constant.ExtensionElementsConstant;
 import com.alibaba.smart.framework.engine.constant.SmartBase;
@@ -20,7 +22,12 @@ import lombok.Data;
  */
 @Data
 public class ExecutionListener  implements ExtensionDecorator {
-    public final static QName qtype = new QName(SmartBase.SMART_NS, "executionListener");
+    public final static List<QName> qtypes = Arrays.asList(
+            new QName(SmartBase.SMART_NS, "executionListener"),
+            new QName(BpmnNameSpaceConstant.CAMUNDA_NAME_SPACE, "executionListener", "camunda"),
+            new QName(BpmnNameSpaceConstant.FLOWABLE_NAME_SPACE, "executionListener", "flowable"),
+            new QName(BpmnNameSpaceConstant.ACTIVITI_NAME_SPACE, "executionListener", "activiti")
+    );
 
     private String[] events;
     private String listenerClass;

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/Properties.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/Properties.java
@@ -1,11 +1,13 @@
 package com.alibaba.smart.framework.engine.smart;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import com.alibaba.smart.framework.engine.bpmn.constant.BpmnNameSpaceConstant;
 import com.alibaba.smart.framework.engine.common.util.MapUtil;
 import com.alibaba.smart.framework.engine.constant.ExtensionElementsConstant;
 import com.alibaba.smart.framework.engine.constant.SmartBase;
@@ -20,7 +22,12 @@ import lombok.Data;
  */
 @Data
 public class Properties implements ExtensionDecorator {
-    public final static QName qtype = new QName(SmartBase.SMART_NS, "properties");
+    public final static List<QName> qtypes = Arrays.asList(
+            new QName(SmartBase.SMART_NS, "properties"),
+            new QName(BpmnNameSpaceConstant.CAMUNDA_NAME_SPACE, "properties", "camunda"),
+            new QName(BpmnNameSpaceConstant.FLOWABLE_NAME_SPACE, "properties", "flowable"),
+            new QName(BpmnNameSpaceConstant.ACTIVITI_NAME_SPACE, "properties", "activiti")
+    );
 
     private List<PropertiesElementMarker> extensionList  = new ArrayList();
 

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/Property.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/Property.java
@@ -1,14 +1,13 @@
 package com.alibaba.smart.framework.engine.smart;
 
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.xml.namespace.QName;
 
-import com.alibaba.smart.framework.engine.common.util.MapUtil;
+import com.alibaba.smart.framework.engine.bpmn.constant.BpmnNameSpaceConstant;
 import com.alibaba.smart.framework.engine.constant.ExtensionElementsConstant;
 import com.alibaba.smart.framework.engine.constant.SmartBase;
-import com.alibaba.smart.framework.engine.model.assembly.ExtensionDecorator;
-import com.alibaba.smart.framework.engine.model.assembly.ExtensionElements;
 import com.alibaba.smart.framework.engine.model.assembly.NoneIdBasedElement;
 
 import lombok.Data;
@@ -16,7 +15,12 @@ import lombok.Data;
 
 @Data
 public class Property implements PropertiesElementMarker, NoneIdBasedElement {
-    public final static QName qtype = new QName(SmartBase.SMART_NS, "property");
+    public final static List<QName> qtypes = Arrays.asList(
+            new QName(SmartBase.SMART_NS, "property"),
+            new QName(BpmnNameSpaceConstant.CAMUNDA_NAME_SPACE, "property", "camunda"),
+            new QName(BpmnNameSpaceConstant.FLOWABLE_NAME_SPACE, "property", "flowable"),
+            new QName(BpmnNameSpaceConstant.ACTIVITI_NAME_SPACE, "property", "activiti")
+    );
 
     private String name;
     private String value;

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/Value.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/Value.java
@@ -1,9 +1,12 @@
 package com.alibaba.smart.framework.engine.smart;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import com.alibaba.smart.framework.engine.bpmn.constant.BpmnNameSpaceConstant;
 import com.alibaba.smart.framework.engine.common.util.MapUtil;
 import com.alibaba.smart.framework.engine.constant.ExtensionElementsConstant;
 import com.alibaba.smart.framework.engine.constant.SmartBase;
@@ -19,7 +22,12 @@ import lombok.Data;
  */
 @Data
 public class Value  implements PropertiesElementMarker, ExtensionDecorator {
-    public final static QName qtype = new QName(SmartBase.SMART_NS, "value");
+    public final static List<QName> qtypes = Arrays.asList(
+            new QName(SmartBase.SMART_NS, "value"),
+            new QName(BpmnNameSpaceConstant.CAMUNDA_NAME_SPACE, "value", "camunda"),
+            new QName(BpmnNameSpaceConstant.FLOWABLE_NAME_SPACE, "value", "flowable"),
+            new QName(BpmnNameSpaceConstant.ACTIVITI_NAME_SPACE, "value", "activiti")
+    );
 
     private String name;
     private String value;

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/ExecutionListenerParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/ExecutionListenerParser.java
@@ -11,6 +11,8 @@ import com.alibaba.smart.framework.engine.xml.parser.AbstractElementParser;
 import com.alibaba.smart.framework.engine.xml.parser.ParseContext;
 import com.alibaba.smart.framework.engine.xml.util.XmlParseUtil;
 
+import java.util.List;
+
 /**
  * @author ettear
  * Created by ettear on 06/08/2017.
@@ -44,7 +46,7 @@ public class ExecutionListenerParser extends AbstractElementParser<ExecutionList
 
     @Override
     public QName getQname() {
-        return ExecutionListener.qtype;
+        return null;
     }
 
     @Override
@@ -52,4 +54,9 @@ public class ExecutionListenerParser extends AbstractElementParser<ExecutionList
         return ExecutionListener.class;
     }
 
+
+    @Override
+    public List<QName> getQnames() {
+       return ExecutionListener.qtypes;
+    }
 }

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/PropertiesParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/PropertiesParser.java
@@ -7,12 +7,12 @@ import com.alibaba.smart.framework.engine.exception.EngineException;
 import com.alibaba.smart.framework.engine.extension.annoation.ExtensionBinding;
 import com.alibaba.smart.framework.engine.extension.constant.ExtensionConstant;
 import com.alibaba.smart.framework.engine.model.assembly.BaseElement;
-import com.alibaba.smart.framework.engine.model.assembly.ExtensionDecorator;
 import com.alibaba.smart.framework.engine.smart.Properties;
 import com.alibaba.smart.framework.engine.smart.PropertiesElementMarker;
-import com.alibaba.smart.framework.engine.smart.Value;
 import com.alibaba.smart.framework.engine.xml.parser.AbstractElementParser;
 import com.alibaba.smart.framework.engine.xml.parser.ParseContext;
+
+import java.util.List;
 
 /**
  * Extension Elements Parser Created by ettear on 16-4-14.
@@ -40,7 +40,12 @@ public class PropertiesParser extends AbstractElementParser<Properties> {
 
     @Override
     public QName getQname() {
-        return Properties.qtype;
+        return null;
+    }
+
+    @Override
+    public List<QName> getQnames() {
+        return Properties.qtypes;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/PropertyParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/PropertyParser.java
@@ -10,6 +10,8 @@ import com.alibaba.smart.framework.engine.xml.parser.AbstractElementParser;
 import com.alibaba.smart.framework.engine.xml.parser.ParseContext;
 import com.alibaba.smart.framework.engine.xml.util.XmlParseUtil;
 
+import java.util.List;
+
 @ExtensionBinding(group = ExtensionConstant.ELEMENT_PARSER, bindKey = Property.class)
 public class PropertyParser extends AbstractElementParser<Property> {
 
@@ -29,7 +31,12 @@ public class PropertyParser extends AbstractElementParser<Property> {
 
     @Override
     public QName getQname() {
-        return Property.qtype;
+        return null;
+    }
+
+    @Override
+    public List<QName> getQnames() {
+        return Property.qtypes;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/ValueParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/smart/parser/ValueParser.java
@@ -10,6 +10,8 @@ import com.alibaba.smart.framework.engine.xml.parser.AbstractElementParser;
 import com.alibaba.smart.framework.engine.xml.parser.ParseContext;
 import com.alibaba.smart.framework.engine.xml.util.XmlParseUtil;
 
+import java.util.List;
+
 /**
  * @author ettear
  * Created by ettear on 06/08/2017.
@@ -30,7 +32,12 @@ public class ValueParser extends AbstractElementParser<Value> {
 
     @Override
     public QName getQname() {
-        return Value.qtype;
+        return null;
+    }
+
+    @Override
+    public List<QName> getQnames() {
+        return Value.qtypes;
     }
 
     @Override

--- a/core/src/main/java/com/alibaba/smart/framework/engine/xml/parser/AbstractElementParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/xml/parser/AbstractElementParser.java
@@ -16,6 +16,9 @@ import com.alibaba.smart.framework.engine.xml.util.XmlParseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author ettear
  * Created by ettear on 06/08/2017.
@@ -111,6 +114,8 @@ public abstract class AbstractElementParser<M extends BaseElement> implements El
 
     }
 
-
-
+    @Override
+    public List<QName> getQnames() {
+        return new ArrayList<QName>();
+    }
 }

--- a/core/src/main/java/com/alibaba/smart/framework/engine/xml/parser/BaseXmlParser.java
+++ b/core/src/main/java/com/alibaba/smart/framework/engine/xml/parser/BaseXmlParser.java
@@ -4,6 +4,8 @@ import javax.xml.namespace.QName;
 
 import com.alibaba.smart.framework.engine.hook.LifeCycleHook;
 
+import java.util.List;
+
 /**
  * Base interface for artifact parsers. Created by ettear on 16-4-12.
  */
@@ -12,6 +14,8 @@ public interface BaseXmlParser<M> extends LifeCycleHook {
 
     // check 是否需要
     QName getQname();
+
+    List<QName> getQnames();
 
     Class<M> getModelType();
     

--- a/core/src/test/java/com/alibaba/smart/framework/engine/extendsion/parser/ExtensionNameSpaceParseTest.java
+++ b/core/src/test/java/com/alibaba/smart/framework/engine/extendsion/parser/ExtensionNameSpaceParseTest.java
@@ -1,0 +1,96 @@
+package com.alibaba.smart.framework.engine.extendsion.parser;
+
+import com.alibaba.smart.framework.engine.SmartEngine;
+import com.alibaba.smart.framework.engine.bpmn.assembly.task.ServiceTask;
+import com.alibaba.smart.framework.engine.configuration.ProcessEngineConfiguration;
+import com.alibaba.smart.framework.engine.configuration.impl.DefaultIdGenerator;
+import com.alibaba.smart.framework.engine.configuration.impl.DefaultProcessEngineConfiguration;
+import com.alibaba.smart.framework.engine.configuration.impl.DefaultSmartEngine;
+import com.alibaba.smart.framework.engine.constant.ExtensionElementsConstant;
+import com.alibaba.smart.framework.engine.extension.scanner.SimpleAnnotationScanner;
+import com.alibaba.smart.framework.engine.model.assembly.IdBasedElement;
+import com.alibaba.smart.framework.engine.model.assembly.ProcessDefinition;
+import com.alibaba.smart.framework.engine.model.assembly.ProcessDefinitionSource;
+import com.alibaba.smart.framework.engine.service.command.ExecutionCommandService;
+import com.alibaba.smart.framework.engine.service.command.ProcessCommandService;
+import com.alibaba.smart.framework.engine.service.command.RepositoryCommandService;
+import com.alibaba.smart.framework.engine.service.query.ExecutionQueryService;
+import com.alibaba.smart.framework.engine.smart.PropertyCompositeKey;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author zilong.jiangzl
+ * @create 2020-07-17 2:29 下午
+ */
+public class ExtensionNameSpaceParseTest {
+
+
+    private SmartEngine smartEngine;
+
+    private RepositoryCommandService repositoryCommandService;
+
+    private ProcessCommandService processCommandService;
+
+    private ExecutionQueryService executionQueryService;
+
+    private ExecutionCommandService executionCommandService;
+
+    @Before
+    public void initEngine() {
+        //1.初始化
+        ProcessEngineConfiguration processEngineConfiguration = new DefaultProcessEngineConfiguration();
+        processEngineConfiguration.setIdGenerator(new DefaultIdGenerator());
+
+        processEngineConfiguration.setAnnotationScanner(
+                new SimpleAnnotationScanner(
+                        SmartEngine.class.getPackage().getName(),
+                        ExtensionNameSpaceParseTest.class.getPackage().getName()));
+        smartEngine = new DefaultSmartEngine();
+        smartEngine.init(processEngineConfiguration);
+
+        //2.获得常用服务
+        repositoryCommandService = smartEngine.getRepositoryCommandService();
+        processCommandService = smartEngine.getProcessCommandService();
+        executionQueryService = smartEngine.getExecutionQueryService();
+        executionCommandService = smartEngine.getExecutionCommandService();
+    }
+
+    @Test
+    public void testCamundaParse() throws Exception {
+        testDifferentNsParse("camunda.bpmn20.xml");
+    }
+
+    @Test
+    public void testFlowableParse() throws Exception {
+        testDifferentNsParse("flowable.bpmn20.xml");
+    }
+
+    private void testDifferentNsParse(String processDefineName) throws Exception {
+        //1. 部署流程定义
+        ProcessDefinitionSource processDefinitionSource = repositoryCommandService
+                .deploy(String.format("process-def/extension/%s", processDefineName));
+
+        ProcessDefinition processDefinition = processDefinitionSource.getProcessDefinitionList().get(0);
+        Assert.assertNotNull(processDefinition);
+
+        for (Map.Entry<String, IdBasedElement> entry : processDefinition.getIdBasedElementMap().entrySet()) {
+            if (entry.getValue() instanceof ServiceTask) {
+                ServiceTask serviceTask = (ServiceTask) entry.getValue();
+                Map<PropertyCompositeKey, String> extensionMap =
+                        (Map<PropertyCompositeKey, String>)serviceTask.getExtensionElements().getDecorationMap().get(ExtensionElementsConstant.PROPERTIES);
+                Assert.assertTrue(extensionMap.size() == 1);
+                final Map<String, String> properties = new HashMap<String, String>();
+                for(Map.Entry<PropertyCompositeKey, String> e :  extensionMap.entrySet()) {
+                    properties.put(e.getKey().getName(), e.getValue());
+                }
+                String taskOption = properties.get("taskOption");
+                Assert.assertEquals(taskOption, "100");
+            }
+        }
+    }
+}

--- a/core/src/test/resources/process-def/extension/camunda.bpmn20.xml
+++ b/core/src/test/resources/process-def/extension/camunda.bpmn20.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="5.1.2">
+    <process id="Process_1" isExecutable="false" versionTag="1.0.0">
+        <startEvent id="StartEvent_1y45yut" name="开始">
+            <outgoing>SequenceFlow_0h21x7r</outgoing>
+        </startEvent>
+        <serviceTask id="Task_1hcentk" name="任务1">
+            <extensionElements>
+                <camunda:properties>
+                    <camunda:property name="taskOption" value="100" />
+                </camunda:properties>
+            </extensionElements>
+            <incoming>SequenceFlow_0h21x7r</incoming>
+            <outgoing>Flow_0qjh9lu</outgoing>
+        </serviceTask>
+        <sequenceFlow id="SequenceFlow_0h21x7r" sourceRef="StartEvent_1y45yut" targetRef="Task_1hcentk" />
+        <endEvent id="Event_0tsuc1k">
+            <incoming>Flow_0qjh9lu</incoming>
+        </endEvent>
+        <sequenceFlow id="Flow_0qjh9lu" sourceRef="Task_1hcentk" targetRef="Event_0tsuc1k" />
+    </process>
+    <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+        <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+            <bpmndi:BPMNEdge id="SequenceFlow_0h21x7r_di" bpmnElement="SequenceFlow_0h21x7r">
+                <omgdi:waypoint x="188" y="120" />
+                <omgdi:waypoint x="240" y="120" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0qjh9lu_di" bpmnElement="Flow_0qjh9lu">
+                <omgdi:waypoint x="340" y="120" />
+                <omgdi:waypoint x="392" y="120" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="StartEvent_1y45yut_di" bpmnElement="StartEvent_1y45yut">
+                <omgdc:Bounds x="152" y="102" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="160" y="145" width="22" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Task_1hcentk_di" bpmnElement="Task_1hcentk">
+                <omgdc:Bounds x="240" y="80" width="100" height="80" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0tsuc1k_di" bpmnElement="Event_0tsuc1k">
+                <omgdc:Bounds x="392" y="102" width="36" height="36" />
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/core/src/test/resources/process-def/extension/flowable.bpmn20.xml
+++ b/core/src/test/resources/process-def/extension/flowable.bpmn20.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:flowable="http://flowable.org/bpmn"
+             id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn"
+             exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="5.1.2">
+    <process id="Process_1" isExecutable="false" versionTag="1.0.0">
+        <startEvent id="StartEvent_1y45yut" name="开始">
+            <outgoing>SequenceFlow_0h21x7r</outgoing>
+        </startEvent>
+        <serviceTask id="Task_1hcentk" name="任务1">
+            <extensionElements>
+                <flowable:properties>
+                    <flowable:property name="taskOption" value="100"/>
+                </flowable:properties>
+            </extensionElements>
+            <incoming>SequenceFlow_0h21x7r</incoming>
+            <outgoing>Flow_0qjh9lu</outgoing>
+        </serviceTask>
+        <sequenceFlow id="SequenceFlow_0h21x7r" sourceRef="StartEvent_1y45yut" targetRef="Task_1hcentk"/>
+        <endEvent id="Event_0tsuc1k">
+            <incoming>Flow_0qjh9lu</incoming>
+        </endEvent>
+        <sequenceFlow id="Flow_0qjh9lu" sourceRef="Task_1hcentk" targetRef="Event_0tsuc1k"/>
+    </process>
+    <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+        <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+            <bpmndi:BPMNEdge id="SequenceFlow_0h21x7r_di" bpmnElement="SequenceFlow_0h21x7r">
+                <omgdi:waypoint x="188" y="120"/>
+                <omgdi:waypoint x="240" y="120"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="Flow_0qjh9lu_di" bpmnElement="Flow_0qjh9lu">
+                <omgdi:waypoint x="340" y="120"/>
+                <omgdi:waypoint x="392" y="120"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="StartEvent_1y45yut_di" bpmnElement="StartEvent_1y45yut">
+                <omgdc:Bounds x="152" y="102" width="36" height="36"/>
+                <bpmndi:BPMNLabel>
+                    <omgdc:Bounds x="160" y="145" width="22" height="14"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Task_1hcentk_di" bpmnElement="Task_1hcentk">
+                <omgdc:Bounds x="240" y="80" width="100" height="80"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="Event_0tsuc1k_di" bpmnElement="Event_0tsuc1k">
+                <omgdc:Bounds x="392" y="102" width="36" height="36"/>
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
本次修改仅影响smart package下element的扩展支持
ns:executionListener
ns:properties
ns:property
ns:value

支持：activiti/flowable/camunda/smart 四种ns