### PR TITLE
MySQL依赖支持6位数的时间戳

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.alibaba.smart.framework</groupId>
         <artifactId>smart-engine</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
     </parent>
 
     <artifactId>smart-engine-core</artifactId>

--- a/extension/retry/retry-common/pom.xml
+++ b/extension/retry/retry-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smart-engine</artifactId>
         <groupId>com.alibaba.smart.framework</groupId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/retry/retry-custom/pom.xml
+++ b/extension/retry/retry-custom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smart-engine</artifactId>
         <groupId>com.alibaba.smart.framework</groupId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/retry/retry-mysql/pom.xml
+++ b/extension/retry/retry-mysql/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smart-engine</artifactId>
         <groupId>com.alibaba.smart.framework</groupId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/storage/storage-common/pom.xml
+++ b/extension/storage/storage-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smart-engine</artifactId>
         <groupId>com.alibaba.smart.framework</groupId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/storage/storage-custom/pom.xml
+++ b/extension/storage/storage-custom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.smart.framework</groupId>
         <artifactId>smart-engine</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/storage/storage-mongodb/pom.xml
+++ b/extension/storage/storage-mongodb/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>smart-engine</artifactId>
         <groupId>com.alibaba.smart.framework</groupId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/storage/storage-mysql/pom.xml
+++ b/extension/storage/storage-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.alibaba.smart.framework</groupId>
         <artifactId>smart-engine</artifactId>
-        <version>2.6.4</version>
+        <version>2.6.5-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
 
     </parent>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/activity_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/activity_instance.xml
@@ -10,7 +10,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ActivityInstanceEntity"  keyProperty="id">
         insert into  se_activity_instance(<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processInstanceId}, #{processDefinitionIdAndVersion},
+        values (#{id}, now(6), now(6), #{processInstanceId}, #{processDefinitionIdAndVersion},
         #{processDefinitionActivityId})
     </insert>
 
@@ -21,7 +21,7 @@
     <!--     <update id="update" parameterType="ActivityInstanceEntity">
             update  se_activity_instance
             <set>
-                gmt_modified=now()
+                gmt_modified=now(6)
                 <if test="status != null"> ,status = #{status}</if>
                 <if test="parentProcessInstanceId != null"> ,parent_process_instance_id = #{parentProcessInstanceId}</if>
             </set>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/deployment_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/deployment_instance.xml
@@ -27,7 +27,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.DeploymentInstanceEntity"  keyProperty="id">
         insert into  se_deployment_instance(<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processDefinitionId}, #{processDefinitionVersion},#{processDefinitionType},#{processDefinitionCode},
+        values (#{id}, now(6), now(6), #{processDefinitionId}, #{processDefinitionVersion},#{processDefinitionType},#{processDefinitionCode},
         #{processDefinitionName},#{processDefinitionDesc},#{processDefinitionContent},
         #{deploymentUserId},#{deploymentStatus} , #{logicStatus})
     </insert>
@@ -38,7 +38,7 @@
 
     <update id="update"  parameterType="com.alibaba.smart.framework.engine.persister.database.entity.DeploymentInstanceEntity">
         update se_deployment_instance set
-        gmt_modified = now()
+        gmt_modified = now(6)
         <if test="processDefinitionId != null"> ,process_definition_id = #{processDefinitionId}</if>
         <if test="processDefinitionVersion != null"> ,process_definition_version = #{processDefinitionVersion}</if>
         <if test="processDefinitionType != null"> ,process_definition_type = #{processDefinitionType}</if>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/execution_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/execution_instance.xml
@@ -12,7 +12,7 @@
     <!-- #{incomeTransitionId},#{incomeActivityInstanceId}, -->
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity"   keyProperty="id">
         insert into  se_execution_instance(<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processInstanceId}, #{processDefinitionIdAndVersion},
+        values (#{id}, now(6), now(6), #{processInstanceId}, #{processDefinitionIdAndVersion},
         #{processDefinitionActivityId}, #{activityInstanceId},#{active})
     </insert>
 
@@ -23,7 +23,7 @@
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
         update  se_execution_instance
         <set>
-            gmt_modified=now()
+            gmt_modified=now(6)
             <if test="active != null">,active = #{active}</if>
         </set>
         where id=#{id}

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/process_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/process_instance.xml
@@ -10,7 +10,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity"   keyProperty="id">
         insert into se_process_instance (<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processDefinitionIdAndVersion},#{processDefinitionType},#{startUserId},
+        values (#{id}, now(6), now(6), #{processDefinitionIdAndVersion},#{processDefinitionType},#{startUserId},
         #{status}, #{parentProcessInstanceId},#{parentExecutionInstanceId}, #{reason}, #{bizUniqueId}, #{title}, #{tag},#{comment})
     </insert>
 
@@ -23,7 +23,7 @@
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity">
         update se_process_instance
         <set>
-            gmt_modified=now()
+            gmt_modified=now(6)
             <if test="status != null">,status = #{status}</if>
             <if test="parentProcessInstanceId != null">,parent_process_instance_id = #{parentProcessInstanceId}</if>
             <if test="reason != null">,reason = #{reason}</if>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_assignee_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_assignee_instance.xml
@@ -10,7 +10,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.TaskAssigneeEntity"   keyProperty="id">
         insert into se_task_assignee_instance(<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processInstanceId},
+        values (#{id}, now(6), now(6), #{processInstanceId},
         #{taskInstanceId},#{assigneeId},#{assigneeType})
     </insert>
 
@@ -21,7 +21,7 @@
     <update id="update" >
         update se_task_assignee_instance
         <set>
-            gmt_modified=now()
+            gmt_modified=now(6)
             <if test="assigneeId != null">,assignee_id = #{assigneeId}</if>
             <!--<if test="assigneeType != null">,assignee_type = #{assigneeType}</if>-->
         </set>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_instance.xml
@@ -12,7 +12,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.TaskInstanceEntity"   keyProperty="id">
         insert into se_task_instance(<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processInstanceId}, #{processDefinitionIdAndVersion},#{processDefinitionType},
+        values (#{id}, now(6), now(6), #{processInstanceId}, #{processDefinitionIdAndVersion},#{processDefinitionType},
         #{activityInstanceId}, #{processDefinitionActivityId},#{executionInstanceId},#{claimUserId},#{priority},#{tag},#{claimTime},#{completeTime},#{status},#{comment},#{extension},#{title})
     </insert>
 
@@ -22,7 +22,7 @@
 
     <sql id="update_sql">
         <set>
-            gmt_modified=now()
+            gmt_modified=now(6)
             <if test="taskInstanceEntity.claimUserId != null">,claim_user_id = #{taskInstanceEntity.claimUserId}</if>
             <if test="taskInstanceEntity.priority != null">,priority = #{taskInstanceEntity.priority}</if>
             <if test="taskInstanceEntity.claimTime != null">,claim_time = #{taskInstanceEntity.claimTime}</if>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/variable_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/variable_instance.xml
@@ -10,7 +10,7 @@
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity"   keyProperty="id">
         insert into se_variable_instance (<include refid="baseColumn"/>)
-        values (#{id}, now(), now(), #{processInstanceId}, #{executionInstanceId},
+        values (#{id}, now(6), now(6), #{processInstanceId}, #{executionInstanceId},
         #{fieldKey},#{fieldType},#{fieldLongValue},#{fieldDoubleValue},#{fieldStringValue} )
     </insert>
 
@@ -21,7 +21,7 @@
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity">
         update se_variable_instance
         <set>
-            gmt_modified=now()
+            gmt_modified=now(6)
             <if test="fieldLongValue != null">,field_long_value = #{fieldLongValue}</if>
             <if test="fieldDoubleValue != null">,field_double_value = #{fieldDoubleValue}</if>
             <if test="fieldStringValue != null">,field_string_value = #{fieldStringValue}</if>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <!--  mvn versions:set -DnewVersion=2.5.4-SNAPSHOT -DgenerateBackupPoms=false  -->
     <!--  mvn versions:set -DnewVersion=2.6.4 -DgenerateBackupPoms=false  -->
 
-    <version>2.6.4</version>
+    <version>2.6.5-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>Smart Engine</name>


### PR DESCRIPTION
需求：对所有节点的创建先后顺序做排序
现状：针对开始节点和用户节点同时创建创建的场景下，无法基于id(分布式ID不保证id的全局有序性)和创建时间判断节点创建的先后顺序，需要更细化的时间戳去区分插入的先后顺序

实现方案：MYSQL持久层中所有通过SQL操作日期的地方，全部采用now(6)代替now()
待定点：MYSQL的初始化表结构SQL是否需要调整？