### PR TITLE
feat:给所有业务数据提供一个以 customerId（可以当做租户id，用户id，企业id 来使用）维度的数据隔离

### DIFF
--- a/extension/storage/storage-common/src/main/java/com/alibaba/smart/framework/engine/persister/common/utils/CustomerTrace.java
+++ b/extension/storage/storage-common/src/main/java/com/alibaba/smart/framework/engine/persister/common/utils/CustomerTrace.java
@@ -1,0 +1,104 @@
+package com.alibaba.smart.framework.engine.persister.common.utils;
+
+import java.util.HashMap;
+
+/**
+ * 基于线程上下文操作属性（企业id，或客户id，或租户id）工具类
+ * yrc on 2025/5/11.
+ */
+public class CustomerTrace {
+    public static final String CUSTOMER_ID = "_$_smart_engine_$_customer_id";
+    private static final ThreadLocal<CustomerTrace> threadLocal = new InheritableThreadLocal<>();
+    private final HashMap<String, String> properties = new HashMap<>();
+
+    public static void putCustomerId(String value) {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace == null) {
+            customerTrace = new CustomerTrace();
+            threadLocal.set(customerTrace);
+        }
+        customerTrace.properties.put(CUSTOMER_ID, value);
+    }
+
+    public static void removeCustomerId() {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            customerTrace.properties.remove(CUSTOMER_ID);
+        }
+    }
+
+    public static String getCustomerId() {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            return customerTrace.properties.get(CUSTOMER_ID);
+        }
+
+        return "-1";
+    }
+
+    public static void putProperty(String key, String value) {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace == null) {
+            customerTrace = new CustomerTrace();
+            threadLocal.set(customerTrace);
+        }
+        customerTrace.properties.put(key, value);
+    }
+
+    public static String getProperty(String key) {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            return customerTrace.properties.get(key);
+        }
+        return null;
+    }
+
+    public static void removeProperty(String key) {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            customerTrace.properties.remove(key);
+        }
+    }
+
+    public static void removeProperties() {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            customerTrace.properties.clear();
+        }
+    }
+
+
+    public static HashMap<String, String> getProperties() {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            return customerTrace.properties;
+        } else {
+            return null;
+        }
+    }
+
+    public static boolean propertyExists(String key) {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            return customerTrace.properties.containsKey(key);
+        } else {
+            return false;
+        }
+    }
+
+    public static int size() {
+        CustomerTrace customerTrace = threadLocal.get();
+        if (customerTrace != null) {
+            return customerTrace.properties.size();
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "customerTrace{" +
+                "map=" + properties +
+                '}';
+    }
+}

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/activity_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/activity_instance.xml
@@ -5,17 +5,19 @@
 
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,
-        process_instance_id,process_definition_id_and_version,process_definition_activity_id
+        process_instance_id,process_definition_id_and_version,process_definition_activity_id,customer_id
     </sql>
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ActivityInstanceEntity"  keyProperty="id">
         insert into  se_activity_instance(<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processInstanceId}, #{processDefinitionIdAndVersion},
-        #{processDefinitionActivityId})
+        #{processDefinitionActivityId},'${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
-        delete from  se_activity_instance where id=#{id}
+        delete from  se_activity_instance
+               where id=#{id}
+               and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <!--     <update id="update" parameterType="ActivityInstanceEntity">
@@ -32,12 +34,14 @@
         select
         <include refid="baseColumn"/>
         from  se_activity_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findAllActivity" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ActivityInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_activity_instance where process_instance_id=#{processInstanceId}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
         order by gmt_modified desc
 
     </select>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/deployment_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/deployment_instance.xml
@@ -6,11 +6,11 @@
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,process_definition_id,process_definition_version,
         process_definition_type,process_definition_code,process_definition_name,process_definition_desc,process_definition_content,
-        deployment_user_id,deployment_status,logic_status
+        deployment_user_id,deployment_status,logic_status,customer_id
     </sql>
 
     <sql id="condition">
-        <where>
+        where customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
             <if test="id != null">and id = #{id}</if>
             <if test="processDefinitionVersion != null">and process_definition_version = #{processDefinitionVersion}</if>
             <if test="processDefinitionType != null">and process_definition_type = #{processDefinitionType}</if>
@@ -22,18 +22,18 @@
             <if test="deploymentStatus != null">and deployment_status = #{deploymentStatus}</if>
             <if test="logicStatus != null">and logic_status = #{logicStatus}</if>
 
-        </where>
     </sql>
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.DeploymentInstanceEntity"  keyProperty="id">
         insert into  se_deployment_instance(<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processDefinitionId}, #{processDefinitionVersion},#{processDefinitionType},#{processDefinitionCode},
         #{processDefinitionName},#{processDefinitionDesc},#{processDefinitionContent},
-        #{deploymentUserId},#{deploymentStatus} , #{logicStatus})
+        #{deploymentUserId},#{deploymentStatus} , #{logicStatus},'${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
         delete from se_deployment_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <update id="update"  parameterType="com.alibaba.smart.framework.engine.persister.database.entity.DeploymentInstanceEntity">
@@ -51,12 +51,14 @@
         <if test="logicStatus != null"> ,logic_status = #{logicStatus}</if>
 
         where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <select id="findOne" resultType="com.alibaba.smart.framework.engine.persister.database.entity.DeploymentInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_deployment_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
 

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/execution_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/execution_instance.xml
@@ -6,18 +6,19 @@
     <!-- income_transition_id,income_activity_instance_id, -->
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,
-        process_instance_id,process_definition_id_and_version,process_definition_activity_id,activity_instance_id,active,block_id
+        process_instance_id,process_definition_id_and_version,process_definition_activity_id,activity_instance_id,active,block_id,customer_id
     </sql>
 
     <!-- #{incomeTransitionId},#{incomeActivityInstanceId}, -->
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity"   keyProperty="id">
         insert into  se_execution_instance(<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processInstanceId}, #{processDefinitionIdAndVersion},
-        #{processDefinitionActivityId}, #{activityInstanceId},#{active},#{blockId})
+        #{processDefinitionActivityId}, #{activityInstanceId},#{active},#{blockId},'${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
         delete from  se_execution_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
@@ -27,12 +28,14 @@
             <if test="active != null">,active = #{active}</if>
         </set>
         where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <select id="findOne" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_execution_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
 
@@ -40,24 +43,28 @@
         select
         <include refid="baseColumn"/>
         from  se_execution_instance where id=#{id} and process_instance_id=#{processInstanceId}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findAllExecutionList" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_execution_instance where process_instance_id=#{processInstanceId}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findActiveExecution" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_execution_instance where process_instance_id=#{processInstanceId} and active = 1
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findByActivityInstanceId" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ExecutionInstanceEntity">
         select
         <include refid="baseColumn"/>
         from  se_execution_instance where process_instance_id=#{processInstanceId} and activity_instance_id = #{activityInstanceId}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
 </mapper>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/process_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/process_instance.xml
@@ -5,13 +5,14 @@
 
     <sql id="baseColumn">
         id, gmt_create, gmt_modified, process_definition_id_and_version,process_definition_type,start_user_id,
-        status, parent_process_instance_id,parent_execution_instance_id, reason, biz_unique_id, title,tag,comment
+        status, parent_process_instance_id,parent_execution_instance_id, reason, biz_unique_id, title,tag,comment,customer_id
     </sql>
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity"   keyProperty="id">
         insert into se_process_instance (<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processDefinitionIdAndVersion},#{processDefinitionType},#{startUserId},
-        #{status}, #{parentProcessInstanceId},#{parentExecutionInstanceId}, #{reason}, #{bizUniqueId}, #{title}, #{tag},#{comment})
+        #{status}, #{parentProcessInstanceId},#{parentExecutionInstanceId}, #{reason}, #{bizUniqueId}, #{title}, #{tag},#{comment},
+        '${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
 
@@ -19,6 +20,7 @@
 
     <delete id="delete" parameterType="long">
         delete from se_process_instance where id=#{id}
+                                          and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity">
@@ -33,24 +35,30 @@
 
         </set>
         where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <select id="findOne" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity">
         select
         <include refid="baseColumn"/>
         from se_process_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="tryLock" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity">
         select
         <include refid="baseColumn"/>
-        from se_process_instance where id=#{id} for update
+        from se_process_instance where  customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+                                    and  id=#{id} for update
+
     </select>
 
     <select id="findOneForUpdate" resultType="com.alibaba.smart.framework.engine.persister.database.entity.ProcessInstanceEntity">
         select
         <include refid="baseColumn"/>
-        from se_process_instance where id=#{id} for update
+        from se_process_instance where
+        customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+        and id=#{id} for update
     </select>
 
 
@@ -72,7 +80,7 @@
     </select>
 
     <sql id="condition">
-        <where>
+        where customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
             <if test="processDefinitionType != null">and process_definition_type = #{processDefinitionType}</if>
             <if test="processDefinitionIdAndVersion != null">and process_definition_id_and_version = #{processDefinitionIdAndVersion}</if>
             <if test="status != null">and status = #{status}</if>
@@ -87,7 +95,6 @@
                     #{item}
                 </foreach>
             </if>
-        </where>
     </sql>
 
 

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_assignee_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_assignee_instance.xml
@@ -5,17 +5,19 @@
 
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,process_instance_id,
-        task_instance_id,assignee_id,assignee_type
+        task_instance_id,assignee_id,assignee_type,customer_id
     </sql>
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.TaskAssigneeEntity"   keyProperty="id">
         insert into se_task_assignee_instance(<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processInstanceId},
-        #{taskInstanceId},#{assigneeId},#{assigneeType})
+        #{taskInstanceId},#{assigneeId},#{assigneeType},
+        '${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
         delete from se_task_assignee_instance where id=#{id}
+                                                and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <update id="update" >
@@ -26,24 +28,29 @@
             <!--<if test="assigneeType != null">,assignee_type = #{assigneeType}</if>-->
         </set>
         where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <select id="findOne" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskAssigneeEntity">
         select
         <include refid="baseColumn"/>
         from se_task_assignee_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findList" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskAssigneeEntity">
         select
         <include refid="baseColumn"/>
         from se_task_assignee_instance where task_instance_id=#{taskInstanceId}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findListForInstanceList" parameterType="java.util.List" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskAssigneeEntity">
         select
         <include refid="baseColumn"/>
-        from se_task_assignee_instance where task_instance_id in
+        from se_task_assignee_instance where
+         customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+         and task_instance_id in
         <foreach item="item" index="index" separator="," open="(" close=")"  collection="list">
             #{item}
         </foreach>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/task_instance.xml
@@ -5,7 +5,7 @@
 
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,process_instance_id, process_definition_id_and_version,process_definition_type,
-        activity_instance_id, process_definition_activity_id, execution_instance_id,claim_user_id,priority,tag,claim_time,complete_time,status,comment,extension,title
+        activity_instance_id, process_definition_activity_id, execution_instance_id,claim_user_id,priority,tag,claim_time,complete_time,status,comment,extension,title,customer_id
     </sql>
 
 
@@ -13,11 +13,13 @@
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.TaskInstanceEntity"   keyProperty="id">
         insert into se_task_instance(<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processInstanceId}, #{processDefinitionIdAndVersion},#{processDefinitionType},
-        #{activityInstanceId}, #{processDefinitionActivityId},#{executionInstanceId},#{claimUserId},#{priority},#{tag},#{claimTime},#{completeTime},#{status},#{comment},#{extension},#{title})
+        #{activityInstanceId}, #{processDefinitionActivityId},#{executionInstanceId},#{claimUserId},#{priority},#{tag},#{claimTime},#{completeTime},#{status},#{comment},#{extension},#{title},
+        '${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
         delete from se_task_instance where id=#{id}
+                                       and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <sql id="update_sql">
@@ -40,12 +42,14 @@
         update se_task_instance
        <include refid="update_sql"/>
         where id=#{taskInstanceEntity.id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <update id="updateFromStatus">
         update se_task_instance
         <include refid="update_sql"/>
         where id=#{taskInstanceEntity.id} and status = #{fromStatus}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
 
@@ -54,18 +58,25 @@
         select
         <include refid="baseColumn"/>
         from se_task_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findTaskByProcessInstanceIdAndStatus" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskInstanceEntity" >
         select
         <include refid="baseColumn"/>
         from se_task_instance where process_instance_id = #{param1} and status = #{param2}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findTaskByAssignee" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskInstanceEntity" parameterType="com.alibaba.smart.framework.engine.service.param.query.TaskInstanceQueryByAssigneeParam">
         select distinct task.id, task.gmt_create, task.gmt_modified,task.process_instance_id, process_definition_id_and_version,
         activity_instance_id,process_definition_activity_id, execution_instance_id,claim_user_id,priority, task.tag, task.process_definition_type, claim_time,complete_time,status,comment,extension,title
-        from  se_task_instance task,se_task_assignee_instance assignee where task.id = assignee.task_instance_id
+        from  se_task_instance task,se_task_assignee_instance assignee where
+
+        task.customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+        and assignee.customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+
+        and task.id = assignee.task_instance_id
 
         <if test = "status != null" > and task.status = #{status} </if>
 
@@ -82,7 +93,10 @@
 
     <select id="countTaskByAssignee" resultType="int" parameterType="com.alibaba.smart.framework.engine.service.param.query.TaskInstanceQueryByAssigneeParam">
         select  count(distinct task.id)
-        from  se_task_instance task,se_task_assignee_instance assignee where task.id = assignee.task_instance_id
+        from  se_task_instance task,se_task_assignee_instance assignee where
+        task.customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+        and assignee.customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
+        and task.id = assignee.task_instance_id
 
         <if test = "status != null" > and task.status = #{status} </if>
 
@@ -137,7 +151,7 @@
     <select id="findTaskList" resultType="com.alibaba.smart.framework.engine.persister.database.entity.TaskInstanceEntity" parameterType="com.alibaba.smart.framework.engine.service.param.query.TaskInstanceQueryParam">
         select  task.id, task.gmt_create, task.gmt_modified,task.process_instance_id, process_definition_id_and_version,
         activity_instance_id,process_definition_activity_id, execution_instance_id,claim_user_id,priority, task.tag, task.process_definition_type, claim_time,complete_time,status,comment,extension,title
-        from  se_task_instance task  where 1=1
+        from  se_task_instance task  where customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
         <include refid="where_condition"/>
 
         order by task.gmt_modified desc
@@ -148,7 +162,7 @@
 
     <select id="count" resultType="int" parameterType="com.alibaba.smart.framework.engine.service.param.query.TaskInstanceQueryParam">
         select  count(task.id)
-        from  se_task_instance task where 1=1
+        from  se_task_instance task where customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
         <include refid="where_condition"/>
 
         <if test="pageOffset != null and pageSize != null">limit #{pageOffset},#{pageSize}</if>

--- a/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/variable_instance.xml
+++ b/extension/storage/storage-mysql/src/main/resources/mybatis/sqlmap/variable_instance.xml
@@ -5,17 +5,19 @@
 
     <sql id="baseColumn">
         id, gmt_create, gmt_modified,process_instance_id,
-         execution_instance_id,field_key,field_type,field_long_value,field_double_value,field_string_value
+         execution_instance_id,field_key,field_type,field_long_value,field_double_value,field_string_value,customer_id
     </sql>
 
     <insert id="insert" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity"   keyProperty="id">
         insert into se_variable_instance (<include refid="baseColumn"/>)
         values (#{id}, #{gmtCreate}, #{gmtModified}, #{processInstanceId}, #{executionInstanceId},
-        #{fieldKey},#{fieldType},#{fieldLongValue},#{fieldDoubleValue},#{fieldStringValue} )
+        #{fieldKey},#{fieldType},#{fieldLongValue},#{fieldDoubleValue},#{fieldStringValue},
+        '${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}')
     </insert>
 
     <delete id="delete" parameterType="long">
         delete from se_variable_instance where id=#{id}
+                                           and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </delete>
 
     <update id="update" parameterType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity">
@@ -27,12 +29,14 @@
             <if test="fieldStringValue != null">,field_string_value = #{fieldStringValue}</if>
         </set>
         where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </update>
 
     <select id="findOne" resultType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity">
         select
         <include refid="baseColumn"/>
         from se_variable_instance where id=#{id}
+        and customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
     </select>
 
     <select id="findList" resultType="com.alibaba.smart.framework.engine.persister.database.entity.VariableInstanceEntity">
@@ -50,10 +54,9 @@
     </select>
 
     <sql id="condition">
-        <where>
+        where  customer_id='${@com.alibaba.smart.framework.engine.persister.common.utils.CustomerTrace@getCustomerId()}'
             <if test="processInstanceId != null">and process_instance_id = #{processInstanceId}</if>
             <if test="executionInstanceId != null">and execution_instance_id = #{executionInstanceId}</if>
-        </where>
     </sql>
 
 </mapper>

--- a/extension/storage/storage-mysql/src/main/resources/sql/schema-h2-only-for-test.sql
+++ b/extension/storage/storage-mysql/src/main/resources/sql/schema-h2-only-for-test.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS `se_deployment_instance` (
   `deployment_user_id` varchar(128) NOT NULL  COMMENT 'deployment user id' ,
   `deployment_status` varchar(64) NOT NULL   COMMENT 'deployment status' ,
   `logic_status` varchar(64) NOT NULL  COMMENT 'logic status' ,
-
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
   PRIMARY KEY (`id`)
 )  ;
 
@@ -31,6 +31,7 @@ CREATE TABLE IF NOT EXISTS `se_process_instance` (
   `comment` varchar(255) DEFAULT NULL   COMMENT 'comment' ,
   `title` varchar(255) DEFAULT NULL  COMMENT 'title' ,
   `tag` varchar(255) DEFAULT NULL  COMMENT 'tag' ,
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
 
   PRIMARY KEY (`id`)
 )   ;
@@ -42,6 +43,7 @@ CREATE TABLE IF NOT EXISTS `se_activity_instance` (
   `process_instance_id` bigint DEFAULT NULL  COMMENT 'process instance id'  ,
   `process_definition_id_and_version` varchar(255) NOT NULL  COMMENT 'process definition id and version'  ,
   `process_definition_activity_id` varchar(64) NOT NULL COMMENT 'process definition activity id'   ,
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
   PRIMARY KEY (`id`)
 )  ;
 
@@ -64,6 +66,7 @@ CREATE TABLE IF NOT EXISTS `se_task_instance` (
   `status` varchar(255) NOT NULL COMMENT 'status'     ,
   `comment` varchar(255) DEFAULT NULL  COMMENT 'comment'  ,
   `extension` varchar(255) DEFAULT NULL COMMENT 'extension'  ,
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
 
   PRIMARY KEY (`id`)
 )   ;
@@ -78,6 +81,7 @@ CREATE TABLE IF NOT EXISTS `se_execution_instance` (
   `activity_instance_id` bigint NOT NULL COMMENT 'activity instance id'   ,
   `active` bigint NOT NULL COMMENT '1:active 0:inactive',
   `block_id` bigint COMMENT '1:active 0:inactive',
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
 
   PRIMARY KEY (`id`)
 )   ;
@@ -91,6 +95,8 @@ CREATE TABLE IF NOT EXISTS `se_task_assignee_instance` (
   `task_instance_id` bigint NOT NULL  COMMENT 'task instance id'  ,
   `assignee_id` varchar(255) NOT NULL  COMMENT 'assignee id'  ,
   `assignee_type` varchar(128) NOT NULL  COMMENT 'assignee type'  ,
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
+
   PRIMARY KEY (`id`)
 )  ;
 
@@ -106,6 +112,7 @@ CREATE TABLE IF NOT EXISTS `se_variable_instance` (
   `field_double_value` decimal(65,30) DEFAULT NULL   COMMENT 'field double value' ,
   `field_long_value` bigint DEFAULT NULL  COMMENT 'field long value'  ,
   `field_string_value` varchar(4000) DEFAULT NULL  COMMENT 'field string value' ,
+  `customer_id` varchar(32) NOT NULL  COMMENT 'customer id' ,
 
   PRIMARY KEY (`id`)
 )  ;


### PR DESCRIPTION
一般企业系统都会做分库分表。目前SmartEngine的所有表结构没有哪个统一的字段适合做分库分表键。给每个 业务表都加了customerId字段，便于使用方根据自己的需求去做分库分表，解决系统压力，